### PR TITLE
[feature] 데이터 전처리 API

### DIFF
--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/entity/RawRestaurant.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/entity/RawRestaurant.java
@@ -96,10 +96,11 @@ public class RawRestaurant {
 		this.refineWgs84Logt = Double.parseDouble(rawRestaurant.optString("REFINE_WGS84_LOGT", "0"));
 	}
 
-	public Restaurant toRestaurant() {
+	public Restaurant toRestaurant(String uniqueKey) {
 		return Restaurant.builder()
-				.nameAddress(this.bizplcNm + this.refineRoadnmAddr)
+				.nameAddress(uniqueKey)
 				.city(this.sigunNm)
+				.name(this.bizplcNm)
 				.licenseDate(this.licensgDe)
 				.businessStatus(this.bsnStateNm)
 				.type(this.sanittnBizcondNm)

--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/entity/RawRestaurant.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/entity/RawRestaurant.java
@@ -6,11 +6,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 import org.json.JSONObject;
 
 @Entity
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/entity/RawRestaurant.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/entity/RawRestaurant.java
@@ -1,5 +1,6 @@
 package com.locationbasedfoodieservice.rawrestaurant.entity;
 
+import com.locationbasedfoodieservice.restaurant.entity.Restaurant;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -63,7 +64,7 @@ public class RawRestaurant {
 	// 소재지지번주소
 	private String refineLotnoAddr;
 	// 소재지우편번호
-	private Integer refineZipCd;
+	private String refineZipCd;
 	// WGS84위도
 	private Double refineWgs84Lat;
 	// WGS84경도
@@ -90,8 +91,23 @@ public class RawRestaurant {
 		this.totEmplyCnt = rawRestaurant.optInt("TOT_EMPLY_CNT");
 		this.refineRoadnmAddr = rawRestaurant.optString("REFINE_ROADNM_ADDR");
 		this.refineLotnoAddr = rawRestaurant.optString("REFINE_LOTNO_ADDR");
-		this.refineZipCd = Integer.parseInt(rawRestaurant.optString("REFINE_ZIP_CD"));
+		this.refineZipCd = rawRestaurant.optString("REFINE_ZIP_CD");
 		this.refineWgs84Lat = Double.parseDouble(rawRestaurant.optString("REFINE_WGS84_LAT", "0"));
 		this.refineWgs84Logt = Double.parseDouble(rawRestaurant.optString("REFINE_WGS84_LOGT", "0"));
+	}
+
+	public Restaurant toRestaurant() {
+		return Restaurant.builder()
+				.nameAddress(this.bizplcNm + this.refineRoadnmAddr)
+				.city(this.sigunNm)
+				.licenseDate(this.licensgDe)
+				.businessStatus(this.bsnStateNm)
+				.type(this.sanittnBizcondNm)
+				.streetAddress(this.refineRoadnmAddr)
+				.lotNumberAddress(this.refineLotnoAddr)
+				.postalCode(this.refineZipCd)
+				.longitude(this.refineWgs84Logt)
+				.latitude(this.refineWgs84Lat)
+				.build();
 	}
 }

--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/repository/RawRestaurantRepository.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/repository/RawRestaurantRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface RawRestaurantRepository extends JpaRepository<RawRestaurant, Long> {
-	Optional<RawRestaurant> findByBizplcNmAndRefineZipCd(String name, Integer zip);
+	Optional<RawRestaurant> findByBizplcNmAndRefineZipCd(String name, String zip);
 }

--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawKimbobScheduler.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawKimbobScheduler.java
@@ -107,7 +107,7 @@ public class RawKimbobScheduler {
 				String REFINE_ZIP_CD = rawRestaurant.getString("REFINE_ZIP_CD");
 
 				RawRestaurant targetRawRestaurant = rawRestaurantRepository
-						.findByBizplcNmAndRefineZipCd(BIZPLC_NM, Integer.parseInt(REFINE_ZIP_CD))
+						.findByBizplcNmAndRefineZipCd(BIZPLC_NM, REFINE_ZIP_CD)
 						.orElse(null);
 
 				if (targetRawRestaurant == null) {

--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawKimbobScheduler.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawKimbobScheduler.java
@@ -132,7 +132,7 @@ public class RawKimbobScheduler {
 							.totEmplyCnt(rawRestaurant.optInt("TOT_EMPLY_CNT"))
 							.refineRoadnmAddr(rawRestaurant.optString("REFINE_ROADNM_ADDR"))
 							.refineLotnoAddr(rawRestaurant.optString("REFINE_LOTNO_ADDR"))
-							.refineZipCd(Integer.parseInt(rawRestaurant.optString("REFINE_ZIP_CD")))
+							.refineZipCd(rawRestaurant.optString("REFINE_ZIP_CD"))
 							.refineWgs84Lat(Double.parseDouble(rawRestaurant.optString("REFINE_WGS84_LAT", "0")))
 							.refineWgs84Logt(Double.parseDouble(rawRestaurant.optString("REFINE_WGS84_LOGT", "0")))
 							.build();

--- a/src/main/java/com/locationbasedfoodieservice/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/locationbasedfoodieservice/restaurant/entity/Restaurant.java
@@ -3,6 +3,7 @@ package com.locationbasedfoodieservice.restaurant.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.locationbasedfoodieservice.rawrestaurant.entity.RawRestaurant;
 import com.locationbasedfoodieservice.review.entity.Review;
 
 import jakarta.persistence.Column;
@@ -15,10 +16,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
 public class Restaurant {
 
 	@Id
@@ -66,9 +69,9 @@ public class Restaurant {
 
 	@Builder
 	public Restaurant(Long id, String nameAddress, String city, String name, String licenseDate,
-			String businessStatus,
-			String type, String streetAddress, String lotNumberAddress, String postalCode,
-			Double longitude, Double latitude) {
+					  String businessStatus,
+					  String type, String streetAddress, String lotNumberAddress, String postalCode,
+					  Double longitude, Double latitude) {
 		this.id = id;
 		this.nameAddress = nameAddress;
 		this.city = city;
@@ -85,5 +88,18 @@ public class Restaurant {
 
 	public void updateRating(double rating) {
 		this.rating = rating;
+	}
+
+	public void update(RawRestaurant rawRestaurant) {
+		this.nameAddress = rawRestaurant.getBizplcNm() + rawRestaurant.getRefineRoadnmAddr();
+		this.city = rawRestaurant.getSigunNm();
+		this.licenseDate = rawRestaurant.getLicensgDe();
+		this.businessStatus = rawRestaurant.getBsnStateNm();
+		this.type = rawRestaurant.getSanittnBizcondNm();
+		this.streetAddress = rawRestaurant.getRefineRoadnmAddr();
+		this.lotNumberAddress = rawRestaurant.getRefineLotnoAddr();
+		this.postalCode = rawRestaurant.getRefineZipCd();
+		this.longitude = rawRestaurant.getRefineWgs84Logt();
+		this.latitude = rawRestaurant.getRefineWgs84Lat();
 	}
 }

--- a/src/main/java/com/locationbasedfoodieservice/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/locationbasedfoodieservice/restaurant/entity/Restaurant.java
@@ -91,8 +91,8 @@ public class Restaurant {
 	}
 
 	public void update(RawRestaurant rawRestaurant) {
-		this.nameAddress = rawRestaurant.getBizplcNm() + rawRestaurant.getRefineRoadnmAddr();
 		this.city = rawRestaurant.getSigunNm();
+		this.name = rawRestaurant.getBizplcNm();
 		this.licenseDate = rawRestaurant.getLicensgDe();
 		this.businessStatus = rawRestaurant.getBsnStateNm();
 		this.type = rawRestaurant.getSanittnBizcondNm();

--- a/src/main/java/com/locationbasedfoodieservice/restaurant/repository/RestaurantRepository.java
+++ b/src/main/java/com/locationbasedfoodieservice/restaurant/repository/RestaurantRepository.java
@@ -3,6 +3,8 @@ package com.locationbasedfoodieservice.restaurant.repository;
 import com.locationbasedfoodieservice.restaurant.entity.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+import java.util.Optional;
 
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+	Optional<Restaurant> findByNameAddress(String nameAddress);
 }

--- a/src/main/java/com/locationbasedfoodieservice/restaurant/scheduler/RestaurantScheduler.java
+++ b/src/main/java/com/locationbasedfoodieservice/restaurant/scheduler/RestaurantScheduler.java
@@ -27,6 +27,8 @@ public class RestaurantScheduler {
 	 */
 	@Scheduled(cron = "0 5 4 * * 6")
 	public void updateRestaurant() {
+		log.info("Data PreProcessing Start");
+
 		List<RawRestaurant> rawRestaurants = rawRestaurantRepository.findAll();
 		List<Restaurant> restaurants = new ArrayList<>();
 

--- a/src/main/java/com/locationbasedfoodieservice/restaurant/scheduler/RestaurantScheduler.java
+++ b/src/main/java/com/locationbasedfoodieservice/restaurant/scheduler/RestaurantScheduler.java
@@ -26,7 +26,7 @@ public class RestaurantScheduler {
 	 * 토요일 새벽 4시에 업데이트 되는 rawRestaurant 데이터를 사용하여
 	 * Restaurant를 업데이트해주는 메서드
 	 */
-	@Scheduled(cron = "0 34 22 * * *")
+	@Scheduled(cron = "0 5 4 * * 6")
 	public void updateRestaurant() {
 		log.info("Data PreProcessing Start");
 

--- a/src/main/java/com/locationbasedfoodieservice/restaurant/scheduler/RestaurantScheduler.java
+++ b/src/main/java/com/locationbasedfoodieservice/restaurant/scheduler/RestaurantScheduler.java
@@ -1,0 +1,48 @@
+package com.locationbasedfoodieservice.restaurant.scheduler;
+
+import com.locationbasedfoodieservice.rawrestaurant.entity.RawRestaurant;
+import com.locationbasedfoodieservice.rawrestaurant.repository.RawRestaurantRepository;
+import com.locationbasedfoodieservice.restaurant.entity.Restaurant;
+import com.locationbasedfoodieservice.restaurant.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j(topic = "PreProcessing Data Scheduling")
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class RestaurantScheduler {
+	private final RestaurantRepository restaurantRepository;
+	private final RawRestaurantRepository rawRestaurantRepository;
+
+	/**
+	 * 토요일 새벽 4시에 업데이트 되는 rawRestaurant 데이터를 사용하여
+	 * Restaurant를 업데이트해주는 메서드
+	 */
+	@Scheduled(cron = "0 5 4 * * 6")
+	public void updateRestaurant() {
+		List<RawRestaurant> rawRestaurants = rawRestaurantRepository.findAll();
+		List<Restaurant> restaurants = new ArrayList<>();
+
+		for (RawRestaurant rawRestaurant : rawRestaurants) {
+			String name = rawRestaurant.getBizplcNm();
+			String address = rawRestaurant.getRefineRoadnmAddr();
+
+			Restaurant restaurant = restaurantRepository.findByNameAddress(name + address)
+					.orElse(null);
+			if (restaurant == null) {
+				restaurants.add(rawRestaurant.toRestaurant());
+				continue;
+			}
+			restaurant.update(rawRestaurant);
+		}
+
+		restaurantRepository.saveAll(restaurants);
+	}
+}


### PR DESCRIPTION
## 관련 Issue

* #26

## 변경 사항

* RawRestaurant의 우편번호 필드가 String으로 변경되었습니다.
  * 저는 RawRestaurant에서 Integer로 작업했는데, Restaurant가 String으로 되어 있어서 같이 맞췄습니다.
* RawRestaurant를 Restaurant로 만드는 toEntity() 메서드를 구현하였습니다.
* 업데이트할 Restaurant에 `@DynamicUpdate` 어노테이션을 추가하였습니다.
* Restaurant에 update() 메서드를 추가하였습니다.
* 토요일 새벽 4시 5분에 업데이트되어 있는 rawRestaurant를 받아와서 Restaurant를 업데이트하는 메서드를 구현하였습니다.
* Restaurant 유일키(Unique Key) name_address는 공백이 없게끔 설정하였습니다.

## Check List

![image](https://github.com/Wanted-Internship-Team-Careerly/Location-Based-Foodie-Service/assets/130378232/6e6e8ed8-da92-47fc-9a83-2ac8391fc99e)

## 트러블 슈팅

* 유일키 중복 저장 문제

처음에 `rawRestaurant`에 없는 데이터를 저장하는 로직에서

```java
List<Restaurant> restaurants = new ArrayList<>();

restaurants.add({저장할 Restaurant});

restaurantRepository.saveAll(restaurants);
```

와 같이 `List`에 저장할 `Restaurant`을 담아서 한꺼번에 저장하는 `saveAll()` 메서드를 호출하였는데
여기서 `List`에 같은 유일키 값이 들어간 객체가 들어가면서 유일키 중복 저장 문제가 생겼다.

그렇다면 `List`에 들어가는 `Restaurant`의 유일키는 겹치지 않게끔 `List`에 넣어줘야 하는데

처음에는 `List`를 하나하나 돌면서 `Restaurant`의 유일키를 가져와서 비교해야 하나? 라는 생각이 들었는데. 그것은 너무 비효율적인 것 같아서 어떻게 하면 효율적으로 유일키가 겹치지 않게끔 저장해놓을 수 있을까 고민하다가 `Map`의 `key`를 이용하면 유일키 문제를 해결할 수 있을 것 같았다.

```java
Map<String, Restaurant> restaurants = new HashMap<>();

restaurants.put(uniqueKey, {저장할 Restaurant});

restaurantRepository.saveAll(restaurants.values());
```

다음과 같이 저장하는 자료구조를 `Map`으로 변경하고 `Map`의 `valueSet`을 저장함으로써 문제를 해결할 수 있었다.
