### PR TITLE
[refactor] 데이터 파이프라인 리팩터링

### DIFF
--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawKimbobScheduler.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawKimbobScheduler.java
@@ -120,15 +120,13 @@ public class RawKimbobScheduler {
 			String REFINE_ZIP_CD = rawRestaurant.getString("REFINE_ZIP_CD");
 
 			// rawRestaurant에 없으면 저장, 있으면 update합니다.
-			RawRestaurant targetRawRestaurant = rawRestaurantRepository
-					.findByBizplcNmAndRefineZipCd(BIZPLC_NM, REFINE_ZIP_CD)
-					.orElse(null);
-			if (targetRawRestaurant == null) {
-				RawRestaurant newRawRestaurant = from(rawRestaurant);
-				saveRawDataList.add(newRawRestaurant);
-				continue;
-			}
-			targetRawRestaurant.update(rawRestaurant);
+			rawRestaurantRepository.findByBizplcNmAndRefineZipCd(BIZPLC_NM, REFINE_ZIP_CD).ifPresentOrElse(
+					targetRawRestaurant -> targetRawRestaurant.update(rawRestaurant),
+					() -> {
+						RawRestaurant newRawRestaurant = from(rawRestaurant);
+						saveRawDataList.add(newRawRestaurant);
+					}
+			);
 		}
 		rawRestaurantRepository.saveAll(saveRawDataList);
 	}


### PR DESCRIPTION
## 관련 Issue

* #28 

<br>

## 변경 사항

### 1. 필드명 변경

```java
long number = dataCount / batchSize + 1;
```
변수명을 `page`로 바꾸었습니다.

### 2. 메서드 분리

기존의 한 스케쥴링 메서드에서
1. JSON 배열 raw데이터들을 받아서 확인 후 없으면 저장 있으면 업데이트하는 메서드
2. JSON을 객체화해주는 메서드
로 분리하였습니다.

### 3. 필요없는 log 정리

dataCount, 스케쥴링 시작과 끝만 표시해주도록 log를 변경하였습니다.

<br>

## Check List

* 깔끔한 로그

![image](https://github.com/Wanted-Internship-Team-Careerly/Location-Based-Foodie-Service/assets/130378232/b358c1dc-def4-4cfe-948e-19ce591da713)

* 테이블 drop 후 다시 DB 저장 테스트 성공

![image](https://github.com/Wanted-Internship-Team-Careerly/Location-Based-Foodie-Service/assets/130378232/f183a15e-8e8d-4d2d-9905-511a487a83d6)

<br>

## 트러블 슈팅

* 발생한 예외

다음과 같이 전역변수를 생성했는데 스케쥴러 클래스가 생성이 안 되는 문제가 발생했다.

```java
private Long dataCount;
private Long batchSize = 999L; 
private Long page = (dataCount / batchSize) + 1;
```

* 원인 분석

dataCount가 정의되지 않아서 page를 계산할 수 없고, 그에 의해서 클래스가 생성이 안 되는 문제가 발생했던 것.

* 수정

1안. `dataCount` 임시로 `0L`로 설정해주기
2안. `page` 변수를 필요한 메서드에 지역변수로 설정 ✅

1안의 경우, `dataCount`를 임시로 0으로 설정해주면 데이터의 변화가 있어도 메서드가 계속 돌아가므로 관리자가 데이터의 변화를 인지하지 못할 가능성이 있다.

2안의 경우, page변수를 지역변수로 설정하면 데이터의 변화가 있어 `dataCount`를 받아오지 못하면 `NullPointerException`이 발생하므로 관리자가 데이터의 변화를 인지할 수 있다. 그리고 `NullPointerException`은 발생해도 프로그램이 꺼지지 않기 때문에 이 안으로 채택했다.
