### PR TITLE
[feature] 데이터 파이프라인 complete

### DIFF
--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/entity/RawRestaurant.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/entity/RawRestaurant.java
@@ -1,10 +1,7 @@
 package com.locationbasedfoodieservice.rawrestaurant.entity;
 
 import com.locationbasedfoodieservice.restaurant.entity.Restaurant;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +15,8 @@ import org.json.JSONObject;
 @NoArgsConstructor
 @AllArgsConstructor
 @DynamicUpdate
+@Table(uniqueConstraints =
+		{@UniqueConstraint(columnNames = {"bizplcNm", "refineZipCd"})})
 public class RawRestaurant {
 
 	@Id

--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/DataType.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/DataType.java
@@ -1,0 +1,21 @@
+package com.locationbasedfoodieservice.rawrestaurant.scheduler;
+
+public enum DataType {
+	KIMBOB("Genrestrtlunch"),
+	CAFE("Genrestrtcate"),
+	CHINESE("Genrestrtchifood"),
+	JAPANESE("Genrestrtjpnfood"),
+	SOUP("Genrestrtsoup"),
+	FAST_FOOD("Genrestrtfastfood");
+
+	private String url;
+
+	DataType(String url) {
+		this.url = url;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+}

--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawRestaurantScheduler.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawRestaurantScheduler.java
@@ -22,8 +22,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j(topic = "Open Api Scheduler Log")
 @Component
@@ -50,11 +50,12 @@ public class RawRestaurantScheduler {
 	 */
 
 	// 데이터 총 개수를 가져와서 dataCount에 넣어줍니다.
-	@Scheduled(cron = "0 0 4 * * 6")
+	@Scheduled(cron = "30 42 10 * * *")
 	public void updateRawRestaurant() {
-		String kimbob = "Genrestrtlunch";
-		countData(kimbob);
-		updateData(kimbob);
+		for (DataType type : DataType.values()) {
+			countData(type.getUrl());
+			updateData(type.getUrl());
+		}
 	}
 
 	/**
@@ -123,7 +124,7 @@ public class RawRestaurantScheduler {
 	 */
 	private void updateOrSaveIfNotExists(JSONArray rawRestaurants) {
 		// DB에 존재하지 않을 경우 list에 담아두고 한꺼번에 저장하기 위한 용도입니다.
-		List<RawRestaurant> saveRawDataList = new ArrayList<>();
+		Map<String, RawRestaurant> saveRawDataList = new HashMap<>();
 
 		for (int j = 0; j < rawRestaurants.length(); j++) {
 			JSONObject rawRestaurant = rawRestaurants.getJSONObject(j);
@@ -141,11 +142,11 @@ public class RawRestaurantScheduler {
 					targetRawRestaurant -> targetRawRestaurant.update(rawRestaurant),
 					() -> {
 						RawRestaurant newRawRestaurant = from(rawRestaurant);
-						saveRawDataList.add(newRawRestaurant);
+						saveRawDataList.put(BIZPLC_NM + REFINE_ZIP_CD, newRawRestaurant);
 					}
 			);
 		}
-		rawRestaurantRepository.saveAll(saveRawDataList);
+		rawRestaurantRepository.saveAll(saveRawDataList.values());
 	}
 
 	/**

--- a/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawRestaurantScheduler.java
+++ b/src/main/java/com/locationbasedfoodieservice/rawrestaurant/scheduler/RawRestaurantScheduler.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-@Slf4j(topic = "Open Api Scheduler Log")
+@Slf4j(topic = "Open API Scheduler Log")
 @Component
 @RequiredArgsConstructor
 @Transactional
@@ -50,7 +50,7 @@ public class RawRestaurantScheduler {
 	 */
 
 	// 데이터 총 개수를 가져와서 dataCount에 넣어줍니다.
-	@Scheduled(cron = "30 42 10 * * *")
+	@Scheduled(cron = "0 0 4 * * 6")
 	public void updateRawRestaurant() {
 		for (DataType type : DataType.values()) {
 			countData(type.getUrl());


### PR DESCRIPTION
## 관련 Issue

* #29
* #31 

## 변경 사항

* rawRestaurant Entity에서 사업장명과 우편번호 컬럼에 동시에 UK를 걸어주었습니다.
* 김밥, 카페, 중식, 일식, 탕류, 패스트 푸드 등의 데이터가 모두 컬럼이 동일하며 API 요청을 보낼 때 끝에 리소스 식별자 String 값만 달라지는 것을 알아내어 이를 Enum으로 관리하며 for문을 돌면서 API요청을 하게끔 구현하였습니다.
* 원래 `RawKimbobScheduler`클래스가 여러 API를 요청하는 기능을 담당하게 되면서 `RawRestaurantScheduler`로 이름이 변경되었습니다.
* 의미있는 메서드 주석을 달려고 노력했습니다.

## Check List

* 특정 값(설정한 unique키가 없는 경우) 외에는 다 save, update가 되는 것을 확인하였습니다. 다만, 데이터가 하나도 없을 때 40분 50초, 데이터가 다 있을 때는 48분 19초로 상당히 느린 시간을 보여주었습니다. 이에 대해 개선할 필요가 보입니다.

![image](https://github.com/Wanted-Internship-Team-Careerly/Location-Based-Foodie-Service/assets/130378232/ef79c535-48e0-4606-bcb1-a87b0b36278a)

![image](https://github.com/Wanted-Internship-Team-Careerly/Location-Based-Foodie-Service/assets/130378232/a3402ca2-cb24-4d28-a9c0-b19d2c19695f)